### PR TITLE
feat: add basic tweet draft functionality

### DIFF
--- a/src/app/draft-actions/draft-actions.component.html
+++ b/src/app/draft-actions/draft-actions.component.html
@@ -5,9 +5,9 @@
   <li class="inline-block">
     <a (click)="deleteDraft(draft.id)">delete</a>
   </li>
-  <!--<li class="inline-block">
-    <a href="">tweet</a>
-  </li>-->
+  <li class="inline-block">
+    <a (click)="tweetDraft(draft.id)">tweet</a>
+  </li>
   <li class="inline-block">
     <a class="fav"
       [ngClass]="{ faved: draft.faved }"

--- a/src/app/draft-actions/draft-actions.component.ts
+++ b/src/app/draft-actions/draft-actions.component.ts
@@ -9,6 +9,7 @@ export class DraftActionsComponent {
   @Input() draft;
   @Output() favDraftClick = new EventEmitter();
   @Output() deleteDraftClick: EventEmitter<any> = new EventEmitter();
+  @Output() tweetDraftClick = new EventEmitter();
 
   favDraft(id) {
     return this.favDraftClick.emit();
@@ -16,5 +17,9 @@ export class DraftActionsComponent {
 
   deleteDraft(id: any) {
     return this.deleteDraftClick.emit(id);
+  }
+
+  tweetDraft(id) {
+    return this.tweetDraftClick.emit();
   }
 }

--- a/src/app/draft/draft.component.html
+++ b/src/app/draft/draft.component.html
@@ -6,6 +6,7 @@
   <app-draft-actions
     [draft]="draft"
     (favDraftClick)="toggleFav()"
-    (deleteDraftClick)="deleteDraft($event)">
+    (deleteDraftClick)="deleteDraft($event)"
+    (tweetDraftClick)="tweetDraft()">
   </app-draft-actions>
 </div>

--- a/src/app/draft/draft.component.ts
+++ b/src/app/draft/draft.component.ts
@@ -52,4 +52,13 @@ export class DraftComponent implements OnInit {
   deleteDraft(id) {
     this.deleteDraftClick.emit(id);
   }
+
+  tweetDraft(id) {
+    const strippedText = this.draft.text.replace(/<[^>]+>/ig, '');
+    window.open(
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(strippedText)}`,
+      'tinydraft',
+      'width=600,height=300'
+    );
+  }
 }

--- a/src/app/draft/draft.component.ts
+++ b/src/app/draft/draft.component.ts
@@ -53,7 +53,7 @@ export class DraftComponent implements OnInit {
     this.deleteDraftClick.emit(id);
   }
 
-  tweetDraft(id) {
+  tweetDraft() {
     const strippedText = this.draft.text.replace(/<[^>]+>/ig, '');
     window.open(
       `https://twitter.com/intent/tweet?text=${encodeURIComponent(strippedText)}`,

--- a/src/app/editor/editor.component.css
+++ b/src/app/editor/editor.component.css
@@ -6,7 +6,7 @@
   position: absolute;
   font-size: 2rem;
   color: #07b6ff;
-  padding: .8rem 0 0 .8rem;
+  padding: .2rem 0 0 .8rem;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Adds a "tweet" action to tweet a draft.
For now the simplest solution was to use https://dev.twitter.com/web/intents

<img width="687" alt="screen shot 2017-04-07 at 23 07 03" src="https://cloud.githubusercontent.com/assets/464300/24820056/7b04056c-1be7-11e7-8dc5-c9ed108eeda1.png">


## Related issue:

#5