### PR TITLE
feat: add a confirm dialog before deleting a draft

### DIFF
--- a/src/app/draft-actions/draft-actions.component.ts
+++ b/src/app/draft-actions/draft-actions.component.ts
@@ -16,7 +16,9 @@ export class DraftActionsComponent {
   }
 
   deleteDraft(id: any) {
-    return this.deleteDraftClick.emit(id);
+    if (window.confirm('Are you sure that you want to delete this draft?')) {
+      return this.deleteDraftClick.emit(id);
+    }
   }
 
   tweetDraft(id) {


### PR DESCRIPTION
Introduce a simple confirmation when clicking "delete" before actually deleting the draft.